### PR TITLE
simplify plugin registration logic

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import {ClientOptions} from "irc";
 import {Bot} from "./domain/bot";
-import {TitsPlugin} from "./plugins/tits/TitsPlugin";
-import {GooglePlugin} from "./plugins/google/GooglePlugin";
+import {PLUGINS} from './plugins';
 
 let server = 'fr.quakenet.org';
 // let server = '127.0.0.1';
@@ -12,7 +11,4 @@ let config = <ClientOptions> {
 };
 
 var bot = new Bot(server, nick, config);
-var tits = new TitsPlugin();
-var google = new GooglePlugin();
-bot.addPlugin(tits);
-bot.addPlugin(google);
+bot.addPlugins(PLUGINS);

--- a/src/domain/bot.ts
+++ b/src/domain/bot.ts
@@ -14,8 +14,8 @@ export class Bot extends Client {
         });
     }
 
-    addPlugin(plugin:IPlugin) {
-        this.plugins.push(plugin);
+    addPlugins(plugins:IPlugin[]) {
+        this.plugins.push(...plugins);
     }
 
     private async parseCommand(from:string, ch:string, msg:Message) {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,4 @@
+import {TitsPlugin} from "./tits/TitsPlugin";
+import {GooglePlugin} from "./google/GooglePlugin";
+
+export const PLUGINS = [new TitsPlugin(), new GooglePlugin()];


### PR DESCRIPTION
Mejor tener un index.ts donde se importan todos los plugins y exportarlos luego y registrarlos de golpe.

Si luego en un futuro hay diferentes necesidades, se cambia.
